### PR TITLE
Process.env should take precedence over .env keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,21 +6,21 @@ const debug = new Debug('dotenv-parse-variables');
 const DEFAULT_OPTIONS = {
   assignToProcessEnv: true,
   overrideProcessEnv: false
-}
- 
+};
+
 export default (env, options) => {
-  const envOptions = Object.assign({}, DEFAULT_OPTIONS, options || {})
+  const envOptions = Object.assign({}, DEFAULT_OPTIONS, options || {});
 
   Object.keys(env).forEach(key => {
     debug(`key "${key}" before type was ${typeof env[key]}`);
     env[key] = parseKey(env[key], key);
     debug(`key "${key}" after type was ${typeof env[key]}`);
-    
+
     if (envOptions.assignToProcessEnv === true) {
       if (envOptions.overrideProcessEnv === true) {
-        process.env[key] = env[key] || process.env[key]
+        process.env[key] = env[key] || process.env[key];
       } else {
-        process.env[key] = process.env[key] || env[key]
+        process.env[key] = process.env[key] || env[key];
       }
     }
   });

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,26 @@ import Debug from 'debug';
 
 const debug = new Debug('dotenv-parse-variables');
 
-export default (env) => {
+const DEFAULT_OPTIONS = {
+  assignToProcessEnv: true,
+  overrideProcessEnv: false
+}
+ 
+export default (env, options) => {
+  const envOptions = Object.assign({}, DEFAULT_OPTIONS, options || {})
 
   Object.keys(env).forEach(key => {
     debug(`key "${key}" before type was ${typeof env[key]}`);
-    process.env[key] = env[key] = parseKey(env[key], key);
+    env[key] = parseKey(env[key], key);
     debug(`key "${key}" after type was ${typeof env[key]}`);
+    
+    if (envOptions.assignToProcessEnv === true) {
+      if (envOptions.overrideProcessEnv === true) {
+        process.env[key] = env[key] || process.env[key]
+      } else {
+        process.env[key] = process.env[key] || env[key]
+      }
+    }
   });
 
   return env;

--- a/test/fixtures/.env
+++ b/test/fixtures/.env
@@ -8,3 +8,5 @@ BLEEP=false*
 PING=ping,true*,2,100
 # note a string between bacticks won't be parsed
 PONG=`some,thing,that,goes,wow`
+# will not replace process.env by default
+HTTP_PROXY=proxy.domain.com:8080

--- a/test/fixtures/env.js
+++ b/test/fixtures/env.js
@@ -5,5 +5,6 @@ module.exports = {
   BOOP: [ 'some', 'thing', 'that', 'goes', 'wow' ],
   BLEEP: 'false',
   PING: [ 'ping', 'true', 2, 100 ],
-  PONG: 'some,thing,that,goes,wow'
+  PONG: 'some,thing,that,goes,wow',
+  HTTP_PROXY: 'proxy.domain.com:8080'
 };

--- a/test/unit/01-basic.test.js
+++ b/test/unit/01-basic.test.js
@@ -4,16 +4,48 @@ import dotenv from 'dotenv';
 import dotenvParseVariables from '../../lib';
 import expectedEnv from '../fixtures/env';
 
-let env = dotenv.config({
-  path: path.join(global.fixturesDir, '.env')
-});
-if (env.error) throw env.error;
-env = dotenvParseVariables(env.parsed);
+const TEST_PROXY = 'do.not.replace.me:9090';
 
 describe('dotenv-parse-variables', () => {
 
+  let env = null;
+
+  beforeEach('load env from fixture', () => {
+    env = dotenv.config({
+      path: path.join(global.fixturesDir, '.env')
+    });
+    if (env.error) throw env.error;
+  });
+
   it('should equal fixture already parsed', () => {
+    env = dotenvParseVariables(env.parsed);
     expect(env).to.deep.equal(expectedEnv);
+  });
+
+  it('should not replace process.env keys by default', () => {
+    process.env.HTTP_PROXY = TEST_PROXY;
+    env = dotenvParseVariables(env.parsed);
+    expect(process.env.HTTP_PROXY).to.equal(TEST_PROXY);
+  });
+
+  it('should not assign process.env keys when disabled', () => {
+    process.env.FOO = 'NOT_FOO';
+    process.env.BAR = 'NOT_BAR';
+    env = dotenvParseVariables(env.parsed, { assignToProcessEnv: false });
+    expect(process.env.FOO).to.equal('NOT_FOO');
+    expect(process.env.BAR).to.equal('NOT_BAR');
+  });
+
+  it('should not replace process.env keys when disabled', () => {
+    process.env.HTTP_PROXY = TEST_PROXY;
+    env = dotenvParseVariables(env.parsed, { assignToProcessEnv: false, overrideProcessEnv: true });
+    expect(process.env.HTTP_PROXY).to.equal(TEST_PROXY);
+  });
+
+  it('should replace process.env keys when overriden', () => {
+    process.env.HTTP_PROXY = TEST_PROXY;
+    env = dotenvParseVariables(env.parsed, { overrideProcessEnv: true });
+    expect(process.env.HTTP_PROXY).to.not.equal(TEST_PROXY);
   });
 
 });


### PR DESCRIPTION
Currently, anything in `process.env` will be clobbered by the current `env` object. This PR fixes that and brings the default behavior to mirror `dotenv-extended` on load.

Since this library is often used in conjunction with other `dotenv` libraries, the behavior should be consistent.

