### PR TITLE
Failing tests for process.env types

### DIFF
--- a/test/unit/01-basic.test.js
+++ b/test/unit/01-basic.test.js
@@ -48,4 +48,10 @@ describe('dotenv-parse-variables', () => {
     expect(process.env.HTTP_PROXY).to.not.equal(TEST_PROXY);
   });
 
+  it('should retain its type when setting the process.env', () => {
+    process.env.HTTP_PROXY = TEST_PROXY;
+    env = dotenvParseVariables(env.parsed);
+    expect(process.env.BOOP).to.equal(env.BOOP);
+  });
+
 });


### PR DESCRIPTION
Just wanted to make a PR showing that the types do not persist in the `process.env`. There is some documentation in the README that seems to indicate this should work.