### PR TITLE
Remove documentation in README about process.env types

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,10 +38,10 @@ PONG=`some,thing,that,goes,wow`
 
 After using this plugin, the environment variables are parsed to their proper types.
 
-To test it out, simply log the `process.env` in your console:
+To test it out, simply log the returned object in your console:
 
 ```js
-console.log(process.env);
+console.log(env);
 ```
 
 And you'll see that it outputs the properly parsed variable types:


### PR DESCRIPTION
This just revises the README to not say that there will be different types on the `process.env`. Open to rewording this.