### PR TITLE
Fix issue with parsing boolean

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ function parseKey(value, key) {
   // Boolean
   if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
     debug(`key ${key} parsed as a Boolean`);
-    return value === 'true';
+    return value.toLowerCase() === 'true';
   }
 
   // Number


### PR DESCRIPTION
Boolean value "True" would be parsed as false since 'True' !== 'true'