### PR TITLE
Fixing parse boolean from string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function parseKey(value, key) {
   }
 
   // Boolean
-  if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
+  if (value.toString().toLowerCase() === 'true' || value.toString().toLowerCase() === 'false') {
     debug(`key ${key} parsed as a Boolean`);
     return value === 'true';
   }


### PR DESCRIPTION
Adds support for parsing booleans that for some reason were already parsed, by adding a toString() call on the value object.