### PR TITLE
Added null condition check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dotenv-parse-variables",
   "description": "Parse dotenv files for Boolean, Array, and Number variable types, built for CrocodileJS",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Nick Baugh <niftylettuce@gmail.com>",
   "bugs": "https://github.com/niftylettuce/dotenv-parse-variables/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dotenv-parse-variables",
   "description": "Parse dotenv files for Boolean, Array, and Number variable types, built for CrocodileJS",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "author": "Nick Baugh <niftylettuce@gmail.com>",
   "bugs": "https://github.com/niftylettuce/dotenv-parse-variables/issues",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,15 @@ export default (env, options) => {
 
   Object.keys(env).forEach(key => {
     debug(`key "${key}" before type was ${typeof env[key]}`);
-    env[key] = parseKey(env[key], key);
-    debug(`key "${key}" after type was ${typeof env[key]}`);
-
-    if (envOptions.assignToProcessEnv === true) {
-      if (envOptions.overrideProcessEnv === true) {
-        process.env[key] = env[key] || process.env[key];
-      } else {
-        process.env[key] = process.env[key] || env[key];
+    if (env[key]) {
+      env[key] = parseKey(env[key], key);
+      debug(`key "${key}" after type was ${typeof env[key]}`);
+      if (envOptions.assignToProcessEnv === true) {
+        if (envOptions.overrideProcessEnv === true) {
+          process.env[key] = env[key] || process.env[key];
+        } else {
+          process.env[key] = process.env[key] || env[key];
+        }
       }
     }
   });


### PR DESCRIPTION
When parsing the environment variables, the code would fail if one of the properties is null. While this was not supposed to happen, we found a case on android, where dotenv returns an empty property and dotenv-parse-variables fails because it can't handle nulls.

This code just ignores the null properties, without interrupting the execution